### PR TITLE
Fix delay on thread creation when null_thread runs

### DIFF
--- a/include/system/process.h
+++ b/include/system/process.h
@@ -15,6 +15,7 @@ struct pcb {
 	__attribute__((aligned(1024))) uint32 l2_table[N_L2_ENTRIES];
 };
 
-void process_create(void (*func)(void*), const void* args, size_t args_size);
+void process_create(void (*func)(void*), const void* args, size_t args_size,
+                    struct registers* regs);
 
 #endif /* SYSTEM_PROCESS_H */

--- a/include/system/scheduler.h
+++ b/include/system/scheduler.h
@@ -9,7 +9,8 @@
 void init_scheduler();
 
 struct pcb* scheduler_register_process(struct pcb* process);
-struct tcb* scheduler_register_thread(struct tcb* thread);
+struct tcb* scheduler_register_thread(struct tcb* thread,
+                                      struct registers* regs);
 void scheduler_cycle(struct registers* regs, bool decrement);
 void kill_cur_thread(struct registers* regs);
 size_t get_cur_thread_index();

--- a/include/system/thread.h
+++ b/include/system/thread.h
@@ -25,6 +25,6 @@ struct tcb {
 void* get_stack_pointer(const size_t index);
 void* get_max_stack_pointer(const size_t index);
 struct tcb* thread_create(struct pcb* p, void (*func)(void*), const void* args,
-                          size_t args_size);
+                          size_t args_size, struct registers* regs);
 
 #endif /* SYSTEM_THREAD_H */

--- a/system/calls.c
+++ b/system/calls.c
@@ -110,7 +110,7 @@ exec_syscall_fork(struct registers* regs)
 		return;
 	}
 
-	process_create(func, args, args_size);
+	process_create(func, args, args_size, regs);
 }
 
 /**
@@ -142,7 +142,7 @@ exec_syscall_create_thread(struct registers* regs)
 		return;
 	}
 
-	thread_create(get_cur_process(), func, args, args_size);
+	thread_create(get_cur_process(), func, args, args_size, regs);
 }
 
 /***************************

--- a/system/process.c
+++ b/system/process.c
@@ -16,7 +16,8 @@ extern char _udata_begin[], _udata_end[], _udata_cpy_begin[];
  * Create a new memory region and start a new thread inside it
  */
 void
-process_create(void (*func)(void*), const void* args, size_t args_size)
+process_create(void (*func)(void*), const void* args, size_t args_size,
+               struct registers* regs)
 {
 	klog(LOG, "Creating new process...");
 
@@ -38,7 +39,7 @@ process_create(void (*func)(void*), const void* args, size_t args_size)
 	memcpy(_udata_begin, _udata_cpy_begin, UDATA_SIZE);
 	switch_memory(get_cur_process()->l2_table);
 
-	struct tcb* thread = thread_create(process, func, args, args_size);
+	struct tcb* thread = thread_create(process, func, args, args_size, regs);
 	if (!thread) {
 		klog(LOG, "Something went wrong creating a new thread.");
 		return;

--- a/system/scheduler.c
+++ b/system/scheduler.c
@@ -169,13 +169,18 @@ scheduler_register_process(struct pcb* process)
  * @return a pointer to the new memory location.
  */
 struct tcb*
-scheduler_register_thread(struct tcb* thread)
+scheduler_register_thread(struct tcb* thread, struct registers* regs)
 {
 	size_t index = get_global_thread_index(thread);
 	if (push_index(&thread_indices_q, index) < 0)
 		return NULL;
 
 	threads[index] = *thread;
+
+	// Directly start the new thread if we are currently running nothing.
+	if (get_cur_thread() == null_thread && regs)
+		scheduler_cycle(regs, false);
+
 	return &(threads[index]);
 }
 

--- a/system/start.c
+++ b/system/start.c
@@ -33,5 +33,5 @@ start_kernel(void)
 	ASSERTM(N_THREADS >= 32, "A minimum of 32 threads should be supported.");
 	init_scheduler();
 
-	process_create(&main_thread, NULL, 0);
+	process_create(&main_thread, NULL, 0, NULL);
 }

--- a/system/thread.c
+++ b/system/thread.c
@@ -83,7 +83,7 @@ init_thread(struct pcb* process, void (*func)(void*))
 
 struct tcb*
 thread_create(struct pcb* p, void (*func)(void*), const void* args,
-              size_t args_size)
+              size_t args_size, struct registers* regs)
 {
 	klog(LOG, "Creating new thread...");
 
@@ -131,7 +131,7 @@ thread_create(struct pcb* p, void (*func)(void*), const void* args,
 		new_thread.regs.r0 = (uint32)NULL;
 
 	// register thread in scheduler
-	struct tcb* scheduled_thread = scheduler_register_thread(&new_thread);
+	struct tcb* scheduled_thread = scheduler_register_thread(&new_thread, regs);
 
 	klog(LOG, "Done creating new thread (p%u,t%u)(pidx%u,tidx%u)",
 	     new_thread.process->pid, new_thread.tid, new_thread.process->index,


### PR DESCRIPTION
Currently when creating a new thread and the null_thread is running, there is a short delay until the timer interrupt fires and the new thread runs.
